### PR TITLE
Update 2021.json to fix Hungarian Grand Prix showing as Dutch Grand Prix

### DIFF
--- a/db/2021.json
+++ b/db/2021.json
@@ -196,7 +196,7 @@
       "tbc": true,
       "round": 12,
       "slug": "hungarian-grand-prix",
-      "localeKey": "dutch-grand-prix",
+      "localeKey": "hungarian-grand-prix",
       "sessions": {
         "fp1" : "2021-07-30T09:00:00Z",
         "fp2" : "2021-07-30T13:00:00Z",


### PR DESCRIPTION
Fixed issue with Hungarian Grand Prix showing up as Dutch Grand Prix fixes #351